### PR TITLE
support nested definitions in schema

### DIFF
--- a/lib/json_xema.ex
+++ b/lib/json_xema.ex
@@ -180,7 +180,7 @@ defmodule JsonXema do
       |> Map.update(:contains, nil, &schema/1)
       |> Map.update(:all_of, nil, &schemas/1)
       |> Map.update(:any_of, nil, &schemas/1)
-      |> Map.update(:definitions, nil, &schemas/1)
+      |> Map.update(:definitions, nil, &definitions/1)
       |> Map.update(:dependencies, nil, &dependencies/1)
       |> Map.update(:else, nil, &schema/1)
       |> Map.update(:format, nil, &to_format_attribute/1)
@@ -266,6 +266,26 @@ defmodule JsonXema do
   defp schemas(list)
        when is_list(list),
        do: Enum.map(list, &schema/1)
+
+  @spec definitions(map) :: map
+  defp definitions(map)
+       when is_map(map),
+       do: map |> map_values(&definition/1) |> Enum.into(%{})
+
+  defp definition(map) when is_map(map) do
+    if is_nested_definition(map) do
+      map |> map_values(&definition/1) |> Enum.into(%{})
+    else
+      schema(map)
+    end
+  end
+
+  defp definition(value), do: schema(value)
+
+  @spec is_nested_definition(map) :: boolean
+  defp is_nested_definition(map) when is_map(map) do
+    map |> Enum.all?(fn {k, v} -> is_binary(k) and is_map(v) end)
+  end
 
   @spec dependencies(map) :: map
   defp dependencies(map),

--- a/test/json_xema/definitions_test.exs
+++ b/test/json_xema/definitions_test.exs
@@ -42,4 +42,24 @@ defmodule JsonXema.DefinitionsTest do
       refute valid?(schema, data)
     end
   end
+
+  describe "nested definition" do
+    setup do
+      %{schema: ~s(
+        {
+          "$ref": "http://json-schema.org/draft-07/schema#"
+        }
+        ) |> Jason.decode!() |> JsonXema.new()}
+    end
+
+    test "two level nested definition", %{schema: schema} do
+      data = %{"definition" => %{"foo" => %{"bar" => %{"type" => "integer"}}}}
+      assert valid?(schema, data)
+    end
+
+    test "three level nested definition", %{schema: schema} do
+      data = %{"definition" => %{"foo" => %{"bar" => %{"foo" => %{"type" => "integer"}}}}}
+      assert valid?(schema, data)
+    end
+  end
 end


### PR DESCRIPTION
 ## What does this code achieve?
support load schema file which has a nested definition, for example
```
{
  "definitions": {
    "common": {
      "Id": {
        "type": "number",
        "minimum": 0,
        "maximum": 100
      }
    }
  }
}
```
## Why we need to support this feature
json_xema is a nice library, but I'm having this problem when loading some schema files and I'm hoping to fix it.

